### PR TITLE
remove debug output from config()

### DIFF
--- a/lib/Hue.js
+++ b/lib/Hue.js
@@ -212,8 +212,6 @@ Hue.prototype.config = function(config,cb) {
     timeout:30000
   };
 
-  console.log(opts);
-
   request(opts,function(e,r,b) {
 
     if (e) cb(e)


### PR DESCRIPTION
removing a rogue `console.log` call from Hue.js

seriously awesome module.  I was looking for a Hue library on npm and all of them were garbage except this one.  This provides the perfect layer of abstraction where necessary, but still passes the errors and messages directly from the api.

fyi i ran into the rogue `console.log` statement when writing this command line utility that uses your library

https://github.com/bahamas10/hue-cli
