### PR TITLE
Fixing discovery for node v0.10.2

### DIFF
--- a/example/discover.js
+++ b/example/discover.js
@@ -1,0 +1,5 @@
+var Hue = require('../');
+
+Hue.discover(function(stations) {
+  console.dir(stations);
+});

--- a/lib/Discoverer.js
+++ b/lib/Discoverer.js
@@ -1,7 +1,6 @@
 var dgram = require('dgram');
 var async = require('async');
 var request = require('request');
-var asyncbind = +process.version.split('.')[1] > 8;
 
 var packet = [
   'M-SEARCH * HTTP/1.1',
@@ -17,11 +16,11 @@ module.exports = function(cb) {
   var client = dgram.createSocket("udp4");
   var message = new Buffer(packet);
 
-  if (asyncbind) {
-    client.bind(next);
-  } else {
+  if (client.bind.length) {
     client.bind();
     next();
+  } else {
+    client.bind(next);
   }
 
   function next() {

--- a/lib/Discoverer.js
+++ b/lib/Discoverer.js
@@ -1,6 +1,7 @@
 var dgram = require('dgram');
 var async = require('async');
 var request = require('request');
+var asyncbind = +process.version.split('.')[1] > 8;
 
 var packet = [
   'M-SEARCH * HTTP/1.1',
@@ -16,12 +17,20 @@ module.exports = function(cb) {
   var client = dgram.createSocket("udp4");
   var message = new Buffer(packet);
 
-  client.bind();
-  createServer(client.address().port,cb);
+  if (asyncbind) {
+    client.bind(next);
+  } else {
+    client.bind();
+    next();
+  }
 
-  client.send(message, 0, message.length, 1900, "239.255.255.250",function() {
-    client.close();
-  });
+  function next() {
+    createServer(client.address().port,cb);
+
+    client.send(message, 0, message.length, 1900, "239.255.255.250",function() {
+      client.close();
+    });
+  }
 };
 
 function createServer(port,cb) {


### PR DESCRIPTION
`dgram` stuff is now asynchronous.  I don't know the finer details, but you can read the discussion here https://github.com/joyent/node/issues/4981 for more information.

If you run discovery on node v0.10 you are greeted with:

```
dgram.js:322
    throw errnoException(process._errno, 'getsockname');
          ^
Error: getsockname EINVAL
    at errnoException (dgram.js:439:11)
    at Socket.address (dgram.js:322:11)
    at Object.module.exports [as discover] (/usr/local/lib/node_modules/hue-cli/node_modules/hue.js/lib/Discoverer.js:20:23)
    at Object.<anonymous> (/usr/local/lib/node_modules/hue-cli/hue-cli.js:191:9)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
```

With the patch i've supplied (I couldn't think of a better way to shim this than to check the node version :( ) it will work on node v0.8 and node v0.10.

```
dave @ [ lifeforce :: (Linux) ] ~/dev/hue.js $ node -v
v0.8.20
dave @ [ lifeforce :: (Linux) ] ~/dev/hue.js $ node example/discover.js 
[ '10.0.1.218' ]
dave @ [ lifeforce :: (Linux) ] ~/dev/hue.js $ sudo ~/dev/scripts/install-node v0.10.2 &>/dev/null
dave @ [ lifeforce :: (Linux) ] ~/dev/hue.js $ node -v
v0.10.2
dave @ [ lifeforce :: (Linux) ] ~/dev/hue.js $ node example/discover.js 
[ '10.0.1.218' ]
```
