### PR TITLE
Implement client.rename()

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,6 @@ Turn on/off that light, `light` being the index received from the client.lights(
 
 ### client.rgb(light,R,G,B,cb)
 Change the RGB colour of the light. Note 0,0,0, is not `off`.
+
+### client.rename(light,name,cb)
+Change the light's name to the string `name`, where `light` is the index received from `client.clients()`.

--- a/lib/Hue.js
+++ b/lib/Hue.js
@@ -56,6 +56,23 @@ Hue.prototype.light = function(light,cb) {
   return this;
 };
 
+Hue.prototype.rename = function(light,name,cb) {
+
+  var opts = {
+    method:'PUT',
+    url:'http://'+this._station+'/api/'+this._key+'/lights/'+light,
+    json:{'name':name},
+    timeout:30000
+  };
+
+  request(opts,function(e,r,b) {
+
+    if (e) cb(e)
+    else if (typeof cb === "function") cb.apply(this,Helpers.parseHueResponse(b));
+  });
+  return this;
+};
+
 Hue.prototype.state = function(light,state,cb) {
 
   var opts = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hue.js",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Library for interacting with a Phillips Hue base station",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`client.rename(light, name, callback)` now exists to support the [Philips light attributes API endpoint](http://developers.meethue.com/1_lightsapi.html#15_set_light_attributes_rename). Added a brief description of the method to the documentation. Bumped the version number as a convenience for publishing a fresh version to NPM.
