### PR TITLE
Fix RGB to HSV converter

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -51,7 +51,7 @@ exports.rgb2hsv = function(r, g, b) {
         saturation = 1 - (min/max);
     }
 
-    return [Math.round(hue), Math.round(saturation), Math.round(value)];
+    return [Math.round(hue), saturation, value];
 }
 
 exports.parseHueResponse = function(r) {


### PR DESCRIPTION
Fix RGB to HSV converter.

Round `saturation` and `value` is a mistake because value is between 0 to 1 and the numbers after the comma are important.

Error exemple with pink color:

Color `pink` => `#FFC0CB` => R: `255`, G: `203`, B: `192` => H: `350°`, S: `0`, V: `1` 

=> Saturation is set to `0` due to the `Math.round`... the good value is `0,25` for 25% of saturation.

And the good result must be:

Color `pink` => `#FFC0CB` => R: `255`, G: `203`, B: `192` => H: `350°`, S: `0.25`, V: `1` 
